### PR TITLE
fix: replace hardcoded model refs with GovCloud-available models

### DIFF
--- a/.opencode/agent/orchestrator.md
+++ b/.opencode/agent/orchestrator.md
@@ -63,9 +63,9 @@ Every token you consume on research is a token you can't use for coordination. Y
 | **@tester** | Tester | Test design, test execution, coverage, regression validation |
 | **@documentation** | Documentation | PlantUML diagrams, ADR updates, API docs, release notes |
 | **@truth_teller** | Truth-Teller (default) | Quick reality checks, single-model feedback |
-| **@truth_teller_opus** | Truth-Teller (Opus) | Part of consensus trio — Claude's perspective |
-| **@truth_teller_qwen** | Truth-Teller (Qwen) | Part of consensus trio — Qwen's perspective |
-| **@truth_teller_grok** | Truth-Teller (Grok) | Part of consensus trio — Grok's perspective |
+| **@truth_teller_sonnet** | Truth-Teller (Sonnet) | Part of consensus trio — Claude's perspective |
+| **@truth_teller_nova** | Truth-Teller (Nova) | Part of consensus trio — Amazon Nova perspective |
+| **@truth_teller_llama** | Truth-Teller (Llama) | Part of consensus trio — Meta Llama perspective |
 
 ### Built-in Agents (Simple Tasks)
 For simple, well-defined tasks, prefer built-in agents:
@@ -235,9 +235,9 @@ Roast this. What's dumb about it? What would you delete?
 ### How to Run Consensus
 ```
 # Launch all three in PARALLEL (single message, multiple tool calls)
-@truth_teller_opus: [question/assessment request]
-@truth_teller_qwen: [same question/assessment request]
-@truth_teller_grok: [same question/assessment request]
+@truth_teller_sonnet: [question/assessment request]
+@truth_teller_nova: [same question/assessment request]
+@truth_teller_llama: [same question/assessment request]
 ```
 
 ### Synthesizing Consensus

--- a/.opencode/command/commit.md
+++ b/.opencode/command/commit.md
@@ -1,6 +1,6 @@
 ---
 description: git commit and push
-model: opencode/kimi-k2.5
+model: amazon-bedrock/amazon.nova-lite-v1:0
 subtask: true
 ---
 

--- a/.opencode/command/issues.md
+++ b/.opencode/command/issues.md
@@ -1,6 +1,6 @@
 ---
 description: "find issue(s) on github"
-model: opencode/claude-haiku-4-5
+model: amazon-bedrock/amazon.nova-lite-v1:0
 ---
 
 Search through existing issues in anomalyco/opencode using the gh cli to find issues matching this query:

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -62,10 +62,10 @@
 			"model": "amazon-bedrock/amazon.nova-pro-v1:0",
 			"prompt": "{file:agent/truth_teller.md}"
 		},
-		"truth_teller_llama": {
-			"description": "Truth-Teller (Llama) - Meta Llama perspective",
+		"truth_teller_lite": {
+			"description": "Truth-Teller (Lite) - Amazon Nova Lite perspective",
 			"mode": "subagent",
-			"model": "amazon-bedrock/meta.llama3-70b-instruct-v1:0",
+			"model": "amazon-bedrock/amazon.nova-lite-v1:0",
 			"prompt": "{file:agent/truth_teller.md}"
 		}
 	}

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -47,25 +47,25 @@
 		"truth_teller": {
 			"description": "Truth-Teller (default) - challenges assumptions and risky plans",
 			"mode": "subagent",
-			"model": "opencode/claude-opus-4-5",
+			"model": "amazon-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0",
 			"prompt": "{file:agent/truth_teller.md}"
 		},
-		"truth_teller_opus": {
-			"description": "Truth-Teller (Opus) - Claude Opus perspective",
+		"truth_teller_sonnet": {
+			"description": "Truth-Teller (Sonnet) - Claude Sonnet perspective",
 			"mode": "subagent",
-			"model": "opencode/claude-opus-4-5",
+			"model": "amazon-bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0",
 			"prompt": "{file:agent/truth_teller.md}"
 		},
-		"truth_teller_qwen": {
-			"description": "Truth-Teller (Qwen) - Qwen3 Coder perspective",
+		"truth_teller_nova": {
+			"description": "Truth-Teller (Nova) - Amazon Nova perspective",
 			"mode": "subagent",
-			"model": "opencode/qwen3-coder-480b",
+			"model": "amazon-bedrock/amazon.nova-pro-v1:0",
 			"prompt": "{file:agent/truth_teller.md}"
 		},
-		"truth_teller_grok": {
-			"description": "Truth-Teller (Grok) - Grok perspective",
+		"truth_teller_llama": {
+			"description": "Truth-Teller (Llama) - Meta Llama perspective",
 			"mode": "subagent",
-			"model": "opencode/grok-3",
+			"model": "amazon-bedrock/meta.llama3-70b-instruct-v1:0",
 			"prompt": "{file:agent/truth_teller.md}"
 		}
 	}


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `.opencode/` config files had 6 hardcoded model references (Claude Opus, Qwen, Grok, Kimi, Haiku) that do not exist in AWS GovCloud Bedrock. When running this fork in ANR mode against GovCloud, model lookups for these fail because the API only serves GovCloud-available models.

This PR replaces all 6 references with models available on GovCloud Bedrock:
- `orchestrator.md`: Replaced Claude Opus to Claude Sonnet 4.5, Qwen/Grok/Kimi to Nova Pro/Llama 3 70B
- `commit.md` / `issues.md`: Replaced Claude Haiku to Nova Lite
- `opencode.jsonc`: Updated truth-teller agent model bindings to match (Sonnet 4.5, Nova Pro, Nova Lite)

In a follow-up commit, the Llama 3 70B truth-teller agent was swapped to Nova Lite because Llama loops indefinitely in subagent/agentic mode (it does not emit clean stop sequences, causing the framework to keep invoking it).

All 6 GovCloud models were verified working via direct Bedrock API calls: Claude Sonnet 4.5, Nova Pro, Nova Lite, Nova Micro, Llama 3 70B, Llama 3 8B.

### How did you verify your code works?

1. `bun typecheck` clean across all 14 packages
2. `bun test` 1317 tests pass (including 59 quota/retry tests)
3. Direct Bedrock API test of all 6 GovCloud models all returned correct responses
4. Live CLI test with `bun dev:anr --env-file .opencode/.env.govcloud` Claude Sonnet 4.5, Nova Lite, Nova Micro all responded correctly through the TUI
5. CloudWatch telemetry confirmed flowing (449 metrics, token usage and active users visible)

### Screenshots / recordings

_N/A config-only changes, no UI modifications._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
