### PR TITLE
feat: automate patch draft releases on dev merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: release
-run-name: "${{ inputs.bump && format('release {0}', inputs.bump) || format('release {0}', github.ref_name) }}"
+run-name: "${{ (github.event_name == 'push' && 'release patch') || (inputs.bump && format('release {0}', inputs.bump)) || format('release {0}', github.ref_name) }}"
 
 on:
+  push:
+    branches:
+      - dev
   workflow_dispatch:
     inputs:
       bump:
@@ -18,7 +21,7 @@ on:
         required: false
         type: string
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.version || inputs.bump }}
+concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.version || inputs.bump || github.sha }}
 
 permissions:
   id-token: write
@@ -47,14 +50,14 @@ jobs:
           opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
 
       - name: Install OpenCode
-        if: inputs.bump || inputs.version
+        if: inputs.bump || inputs.version || github.event_name == 'push'
         run: bun i -g opencode-ai
 
       - id: version
         run: ./script/version-tag.ts
         env:
           GH_TOKEN: ${{ steps.committer.outputs.token }}
-          OPENCODE_BUMP: ${{ inputs.bump }}
+          OPENCODE_BUMP: ${{ inputs.bump || (github.event_name == 'push' && 'patch') }}
           OPENCODE_VERSION: ${{ inputs.version }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GH_REPO: ${{ (github.ref_name == 'beta' && 'anomalyco/opencode-beta') || github.repository }}


### PR DESCRIPTION
### Issue for this PR

Closes #146

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds automatic draft patch releases for changes merged into the `dev` branch.

Changes:
- Adds a workflow trigger for pushes to `dev`
- Automatically performs a patch version bump for `dev`-triggered releases
- Continues creating draft GitHub releases
- Preserves existing manual workflow dispatch functionality
- Manual dispatch continues to support preview, patch, minor, major, and version override releases

### How did you verify your code works?

- Reviewed workflow changes against ticket acceptance criteria
- Verified the workflow now triggers on pushes to dev
- Verified dev-triggered releases automatically use a patch bump
- Verified manual workflow_dispatch behavior remains unchanged

### Screenshots / recordings

N/A