### PR TITLE
feat(sync): add automated upstream conflict resolution

### DIFF
--- a/.github/conflict-rules.conf
+++ b/.github/conflict-rules.conf
@@ -1,0 +1,41 @@
+# Upstream sync conflict resolution rules
+#
+# Format:
+# pattern:strategy
+#
+# Supported strategies:
+# ours     = keep our fork/custom version
+# theirs   = take upstream version
+# escalate = do not auto-resolve; require manual review
+#
+# Matching semantics:
+# Last matching rule wins.
+# Put broad rules first and ANR/custom protected rules later.
+# This ensures paths like packages/anr-core/README.md resolve as ours
+# instead of being caught by a broader README or *.md rule.
+
+# Files that are generally safe to take from upstream.
+docs/*:theirs
+doco/*:theirs
+*.snap:theirs
+
+# Mixed-ownership files should not be blindly overwritten.
+README*:escalate
+*.md:escalate
+*.lock:escalate
+bun.lock:escalate
+*.json:escalate
+*.jsonc:escalate
+
+# ANR/custom workflow and integration areas should be preserved.
+.github/workflows/*:ours
+.github/scripts/*:ours
+.github/conflict-rules.conf:ours
+packages/anr-core/*:ours
+*auth*:ours
+*telemetry*:ours
+*provider*:ours
+*bedrock*:ours
+*aws*:ours
+*oidc*:ours
+*federation*:ours

--- a/.github/scripts/resolve-conflicts.sh
+++ b/.github/scripts/resolve-conflicts.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SUMMARY_FILE="/tmp/resolution-summary.md"
+
+resolved_files=()
+escalated_files=()
+
+conflicted_files=$(git diff --name-only --diff-filter=U || true)
+
+{
+  echo "## Automated Upstream Sync Resolution Summary"
+  echo
+  echo "### Conflicted Files"
+  echo
+} > "$SUMMARY_FILE"
+
+if [ -z "$conflicted_files" ]; then
+  echo "No conflicted files detected." >> "$SUMMARY_FILE"
+  echo "resolved_count=0" >> "$GITHUB_OUTPUT"
+  echo "escalated_count=0" >> "$GITHUB_OUTPUT"
+  echo "resolved_files=" >> "$GITHUB_OUTPUT"
+  echo "escalated_files=" >> "$GITHUB_OUTPUT"
+  echo "can_complete_merge=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+
+  echo "- \`$file\`" >> "$SUMMARY_FILE"
+
+  case "$file" in
+    README*|*.md|docs/*|doco/*)
+      git checkout --theirs -- "$file"
+      git add "$file"
+      resolved_files+=("$file")
+      ;;
+
+    *.snap|*.lock|bun.lock|*.json|*.jsonc)
+      git checkout --theirs -- "$file"
+      git add "$file"
+      resolved_files+=("$file")
+      ;;
+
+    .github/workflows/*|packages/anr-core/*|*auth*|*telemetry*|*provider*|*bedrock*|*aws*|*oidc*|*federation*)
+      git checkout --ours -- "$file"
+      git add "$file"
+      resolved_files+=("$file")
+      ;;
+
+    *)
+      escalated_files+=("$file")
+      ;;
+  esac
+done <<< "$conflicted_files"
+
+remaining_conflicts=$(git diff --name-only --diff-filter=U || true)
+
+resolved_csv=$(IFS=, ; echo "${resolved_files[*]:-}")
+escalated_csv=$(IFS=, ; echo "${escalated_files[*]:-}")
+
+{
+  echo
+  echo "### Automated Resolution"
+  echo
+  echo "- Resolved files: ${#resolved_files[@]}"
+  echo "- Escalated files: ${#escalated_files[@]}"
+  echo
+  echo "### Resolved Files"
+  echo
+  if [ ${#resolved_files[@]} -eq 0 ]; then
+    echo "None"
+  else
+    for file in "${resolved_files[@]}"; do
+      echo "- \`$file\`"
+    done
+  fi
+  echo
+  echo "### Escalated Files"
+  echo
+  if [ ${#escalated_files[@]} -eq 0 ]; then
+    echo "None"
+  else
+    for file in "${escalated_files[@]}"; do
+      echo "- \`$file\`"
+    done
+  fi
+  echo
+  echo "### Remaining Conflicts"
+  echo
+  if [ -z "$remaining_conflicts" ]; then
+    echo "None"
+  else
+    echo "$remaining_conflicts" | sed 's/^/- `/' | sed 's/$/`/'
+  fi
+} >> "$SUMMARY_FILE"
+
+echo "resolved_count=${#resolved_files[@]}" >> "$GITHUB_OUTPUT"
+echo "escalated_count=${#escalated_files[@]}" >> "$GITHUB_OUTPUT"
+echo "resolved_files=$resolved_csv" >> "$GITHUB_OUTPUT"
+echo "escalated_files=$escalated_csv" >> "$GITHUB_OUTPUT"
+
+if [ -z "$remaining_conflicts" ] && [ ${#escalated_files[@]} -eq 0 ]; then
+  echo "can_complete_merge=true" >> "$GITHUB_OUTPUT"
+else
+  echo "can_complete_merge=false" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/resolve-conflicts.sh
+++ b/.github/scripts/resolve-conflicts.sh
@@ -6,13 +6,14 @@ SUMMARY_FILE="${SUMMARY_FILE:-/tmp/resolution-summary.md}"
 ESCALATION_LOG="${ESCALATION_LOG:-.github/conflict-escalations.log}"
 GITHUB_OUTPUT="${GITHUB_OUTPUT:-/tmp/resolve-conflicts-output}"
 
+touch "$GITHUB_OUTPUT"
+
 if [ ! -f "$RULES_FILE" ]; then
   echo "Error: conflict rules file not found: $RULES_FILE" >&2
   echo "can_complete_merge=false" >> "$GITHUB_OUTPUT"
   exit 1
 fi
 
-touch "$GITHUB_OUTPUT"
 mkdir -p "$(dirname "$ESCALATION_LOG")"
 
 patterns=()
@@ -127,6 +128,7 @@ append_first_conflict_hunk() {
   echo "<summary>First conflict hunk</summary>"
   echo
   echo '```'
+
   if [ -f "$file" ]; then
     awk '
       /^<<<<<<< / { in_hunk=1 }
@@ -143,20 +145,29 @@ append_first_conflict_hunk() {
   else
     echo "File not available in workspace."
   fi
+
   echo '```'
   echo
   echo "</details>"
 }
 
+write_outputs() {
+  local can_complete_merge="$1"
+  local resolved_count="${#resolved_files[@]}"
+  local escalated_count="${#escalated_files[@]}"
+
+  {
+    echo "resolved_count=$resolved_count"
+    echo "escalated_count=$escalated_count"
+    echo "resolved_files=$(join_by_comma "${resolved_files[@]+"${resolved_files[@]}"}")"
+    echo "escalated_files=$(join_by_comma "${escalated_files[@]+"${escalated_files[@]}"}")"
+    echo "can_complete_merge=$can_complete_merge"
+  } >> "$GITHUB_OUTPUT"
+}
+
 if [ -z "$conflicted_files" ]; then
   echo "No conflicted files detected." >> "$SUMMARY_FILE"
-  {
-    echo "resolved_count=0"
-    echo "escalated_count=0"
-    echo "resolved_files="
-    echo "escalated_files="
-    echo "can_complete_merge=true"
-  } >> "$GITHUB_OUTPUT"
+  write_outputs "true"
   exit 0
 fi
 
@@ -199,6 +210,7 @@ while IFS= read -r file; do
       now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
       append_unresolved_rule "$file" "$now"
       count="$(record_escalation "$file" "$now")"
+
       {
         echo "### Escalated: \`$file\`"
         echo
@@ -248,13 +260,7 @@ else
   can_complete_merge="true"
 fi
 
-{
-  echo "resolved_count=${#resolved_files[@]}"
-  echo "escalated_count=${#escalated_files[@]}"
-  echo "resolved_files=$(join_by_comma "${resolved_files[@]}")"
-  echo "escalated_files=$(join_by_comma "${escalated_files[@]}")"
-  echo "can_complete_merge=$can_complete_merge"
-} >> "$GITHUB_OUTPUT"
+write_outputs "$can_complete_merge"
 
 if [ "$can_complete_merge" = "false" ]; then
   echo "Automated conflict resolution escalated one or more files for manual review." >&2

--- a/.github/scripts/resolve-conflicts.sh
+++ b/.github/scripts/resolve-conflicts.sh
@@ -1,108 +1,261 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SUMMARY_FILE="/tmp/resolution-summary.md"
+RULES_FILE="${RULES_FILE:-.github/conflict-rules.conf}"
+SUMMARY_FILE="${SUMMARY_FILE:-/tmp/resolution-summary.md}"
+ESCALATION_LOG="${ESCALATION_LOG:-.github/conflict-escalations.log}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/tmp/resolve-conflicts-output}"
+
+if [ ! -f "$RULES_FILE" ]; then
+  echo "Error: conflict rules file not found: $RULES_FILE" >&2
+  echo "can_complete_merge=false" >> "$GITHUB_OUTPUT"
+  exit 1
+fi
+
+touch "$GITHUB_OUTPUT"
+mkdir -p "$(dirname "$ESCALATION_LOG")"
+
+patterns=()
+strategies=()
+
+trim() {
+  sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+  line="$(printf '%s' "$raw_line" | trim)"
+  [ -z "$line" ] && continue
+  [[ "$line" == \#* ]] && continue
+
+  if [[ "$line" != *:* ]]; then
+    echo "Error: invalid conflict rule '$line'. Expected pattern:strategy." >&2
+    echo "can_complete_merge=false" >> "$GITHUB_OUTPUT"
+    exit 1
+  fi
+
+  pattern="${line%%:*}"
+  strategy="${line##*:}"
+  pattern="$(printf '%s' "$pattern" | trim)"
+  strategy="$(printf '%s' "$strategy" | trim)"
+
+  case "$strategy" in
+    ours|theirs|escalate) ;;
+    *)
+      echo "Error: invalid strategy '$strategy' for pattern '$pattern'. Use ours, theirs, or escalate." >&2
+      echo "can_complete_merge=false" >> "$GITHUB_OUTPUT"
+      exit 1
+      ;;
+  esac
+
+  patterns+=("$pattern")
+  strategies+=("$strategy")
+done < "$RULES_FILE"
+
+if [ "${#patterns[@]}" -eq 0 ]; then
+  echo "Error: no active conflict rules found in $RULES_FILE" >&2
+  echo "can_complete_merge=false" >> "$GITHUB_OUTPUT"
+  exit 1
+fi
 
 resolved_files=()
+resolved_details=()
 escalated_files=()
 
-conflicted_files=$(git diff --name-only --diff-filter=U || true)
+conflicted_files="$(git diff --name-only --diff-filter=U || true)"
 
 {
   echo "## Automated Upstream Sync Resolution Summary"
   echo
-  echo "### Conflicted Files"
+  echo "Rules file: \`$RULES_FILE\`"
+  echo
+  echo "Matching semantics: last matching rule wins. Broad rules should appear first; ANR/custom protected rules should appear later."
   echo
 } > "$SUMMARY_FILE"
 
+join_by_comma() {
+  local IFS=,
+  echo "$*"
+}
+
+has_local_mod_history() {
+  local file="$1"
+  git log --diff-filter=M --follow --format=%H -- "$file" | head -n 1 | grep -q .
+}
+
+strategy_for_file() {
+  local file="$1"
+  local selected="escalate"
+  local i
+
+  for i in "${!patterns[@]}"; do
+    local pattern="${patterns[$i]}"
+    if [[ "$file" == $pattern ]]; then
+      selected="${strategies[$i]}"
+    fi
+  done
+
+  echo "$selected"
+}
+
+append_unresolved_rule() {
+  local file="$1"
+  local now="$2"
+
+  if ! grep -Fq "$file:" "$RULES_FILE"; then
+    {
+      echo
+      echo "# UNRESOLVED (added $now): $file"
+      echo "# $file:escalate"
+    } >> "$RULES_FILE"
+  fi
+}
+
+record_escalation() {
+  local file="$1"
+  local now="$2"
+
+  touch "$ESCALATION_LOG"
+  echo "$now,$file" >> "$ESCALATION_LOG"
+  grep -F ",$file" "$ESCALATION_LOG" | wc -l | tr -d ' '
+}
+
+append_first_conflict_hunk() {
+  local file="$1"
+
+  echo
+  echo "<details>"
+  echo "<summary>First conflict hunk</summary>"
+  echo
+  echo '```'
+  if [ -f "$file" ]; then
+    awk '
+      /^<<<<<<< / { in_hunk=1 }
+      in_hunk {
+        print
+        count++
+        if (/^>>>>>>> /) exit
+        if (count >= 20) {
+          print "..."
+          exit
+        }
+      }
+    ' "$file" || true
+  else
+    echo "File not available in workspace."
+  fi
+  echo '```'
+  echo
+  echo "</details>"
+}
+
 if [ -z "$conflicted_files" ]; then
   echo "No conflicted files detected." >> "$SUMMARY_FILE"
-  echo "resolved_count=0" >> "$GITHUB_OUTPUT"
-  echo "escalated_count=0" >> "$GITHUB_OUTPUT"
-  echo "resolved_files=" >> "$GITHUB_OUTPUT"
-  echo "escalated_files=" >> "$GITHUB_OUTPUT"
-  echo "can_complete_merge=true" >> "$GITHUB_OUTPUT"
+  {
+    echo "resolved_count=0"
+    echo "escalated_count=0"
+    echo "resolved_files="
+    echo "escalated_files="
+    echo "can_complete_merge=true"
+  } >> "$GITHUB_OUTPUT"
   exit 0
 fi
+
+{
+  echo "### Conflicted files"
+  echo
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    echo "- \`$file\`"
+  done <<< "$conflicted_files"
+  echo
+} >> "$SUMMARY_FILE"
 
 while IFS= read -r file; do
   [ -z "$file" ] && continue
 
-  echo "- \`$file\`" >> "$SUMMARY_FILE"
+  strategy="$(strategy_for_file "$file")"
+  reason=""
 
-  case "$file" in
-    README*|*.md|docs/*|doco/*)
-      git checkout --theirs -- "$file"
-      git add "$file"
-      resolved_files+=("$file")
-      ;;
+  if [ "$strategy" = "theirs" ] && has_local_mod_history "$file"; then
+    strategy="escalate"
+    reason="Matched a theirs rule, but local modification history exists; manual review required to protect customizations."
+  fi
 
-    *.snap|*.lock|bun.lock|*.json|*.jsonc)
-      git checkout --theirs -- "$file"
-      git add "$file"
-      resolved_files+=("$file")
-      ;;
-
-    .github/workflows/*|packages/anr-core/*|*auth*|*telemetry*|*provider*|*bedrock*|*aws*|*oidc*|*federation*)
+  case "$strategy" in
+    ours)
       git checkout --ours -- "$file"
       git add "$file"
       resolved_files+=("$file")
+      resolved_details+=("$file (ours)")
       ;;
-
-    *)
+    theirs)
+      git checkout --theirs -- "$file"
+      git add "$file"
+      resolved_files+=("$file")
+      resolved_details+=("$file (theirs, no local modification history detected)")
+      ;;
+    escalate)
       escalated_files+=("$file")
+      now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+      append_unresolved_rule "$file" "$now"
+      count="$(record_escalation "$file" "$now")"
+      {
+        echo "### Escalated: \`$file\`"
+        echo
+        if [ -n "$reason" ]; then
+          echo "- Reason: $reason"
+        else
+          echo "- Reason: no safe auto-resolution rule matched or the matching rule requested escalation."
+        fi
+        echo "- Recorded escalation count: $count"
+        if [ "$count" -ge 3 ]; then
+          echo "- Recurring: yes — needs a permanent rule."
+        fi
+        echo "- Suggested next step: review the conflict, then uncomment or add a rule in \`$RULES_FILE\` with the correct strategy."
+        append_first_conflict_hunk "$file"
+        echo
+      } >> "$SUMMARY_FILE"
       ;;
   esac
 done <<< "$conflicted_files"
 
-remaining_conflicts=$(git diff --name-only --diff-filter=U || true)
-
-resolved_csv=$(IFS=, ; echo "${resolved_files[*]:-}")
-escalated_csv=$(IFS=, ; echo "${escalated_files[*]:-}")
-
 {
+  echo "### Safely resolved files"
   echo
-  echo "### Automated Resolution"
-  echo
-  echo "- Resolved files: ${#resolved_files[@]}"
-  echo "- Escalated files: ${#escalated_files[@]}"
-  echo
-  echo "### Resolved Files"
-  echo
-  if [ ${#resolved_files[@]} -eq 0 ]; then
-    echo "None"
+  if [ "${#resolved_details[@]}" -eq 0 ]; then
+    echo "- None"
   else
-    for file in "${resolved_files[@]}"; do
-      echo "- \`$file\`"
+    for detail in "${resolved_details[@]}"; do
+      echo "- \`$detail\`"
     done
   fi
   echo
-  echo "### Escalated Files"
+  echo "### Files requiring manual review"
   echo
-  if [ ${#escalated_files[@]} -eq 0 ]; then
-    echo "None"
+  if [ "${#escalated_files[@]}" -eq 0 ]; then
+    echo "- None"
   else
     for file in "${escalated_files[@]}"; do
       echo "- \`$file\`"
     done
   fi
   echo
-  echo "### Remaining Conflicts"
-  echo
-  if [ -z "$remaining_conflicts" ]; then
-    echo "None"
-  else
-    echo "$remaining_conflicts" | sed 's/^/- `/' | sed 's/$/`/'
-  fi
 } >> "$SUMMARY_FILE"
 
-echo "resolved_count=${#resolved_files[@]}" >> "$GITHUB_OUTPUT"
-echo "escalated_count=${#escalated_files[@]}" >> "$GITHUB_OUTPUT"
-echo "resolved_files=$resolved_csv" >> "$GITHUB_OUTPUT"
-echo "escalated_files=$escalated_csv" >> "$GITHUB_OUTPUT"
-
-if [ -z "$remaining_conflicts" ] && [ ${#escalated_files[@]} -eq 0 ]; then
-  echo "can_complete_merge=true" >> "$GITHUB_OUTPUT"
+if [ "${#escalated_files[@]}" -gt 0 ]; then
+  can_complete_merge="false"
 else
-  echo "can_complete_merge=false" >> "$GITHUB_OUTPUT"
+  can_complete_merge="true"
+fi
+
+{
+  echo "resolved_count=${#resolved_files[@]}"
+  echo "escalated_count=${#escalated_files[@]}"
+  echo "resolved_files=$(join_by_comma "${resolved_files[@]}")"
+  echo "escalated_files=$(join_by_comma "${escalated_files[@]}")"
+  echo "can_complete_merge=$can_complete_merge"
+} >> "$GITHUB_OUTPUT"
+
+if [ "$can_complete_merge" = "false" ]; then
+  echo "Automated conflict resolution escalated one or more files for manual review." >&2
 fi

--- a/.github/workflows/upstream-sync-threshold.yml
+++ b/.github/workflows/upstream-sync-threshold.yml
@@ -1,12 +1,10 @@
-name: upstream-sync-threshold
+name: Upstream Sync Threshold
 
 on:
-  schedule:
-    - cron: "0 * * * *" # hourly
   workflow_dispatch:
     inputs:
       upstream_ref:
-        description: "Upstream branch or ref to sync from (default: dev)"
+        description: "Upstream branch/ref to sync from"
         required: false
         default: "dev"
         type: string
@@ -15,85 +13,148 @@ on:
         required: false
         default: "75"
         type: string
+  schedule:
+    - cron: "0 * * * *"
 
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
+  group: upstream-sync-threshold
+  cancel-in-progress: false
 
 permissions:
   contents: write
   pull-requests: write
-  issues: write
 
 jobs:
-  sync:
+  upstream-sync-threshold:
+    name: Threshold-based upstream sync
     runs-on: ubuntu-latest
+
     env:
-      HUSKY: "0"
-      SYNC_BRANCH: sync/upstream
       UPSTREAM_REPO: https://github.com/sst/opencode.git
-      UPSTREAM_REF: ${{ inputs.upstream_ref || 'dev' }}
+      UPSTREAM_REF: ${{ github.event.inputs.upstream_ref || 'dev' }}
       TARGET_BRANCH: dev
-      MIN_COMMITS: ${{ inputs.min_commits || '75' }}
+      MIN_COMMITS: ${{ github.event.inputs.min_commits || '75' }}
+      SYNC_BRANCH: sync/upstream-threshold
+
     steps:
       - name: Checkout dev
         uses: actions/checkout@v4
         with:
+          ref: ${{ env.TARGET_BRANCH }}
           fetch-depth: 0
-          ref: dev
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Bun
-        uses: ./.github/actions/setup-bun
-
-      - name: Setup Git Committer
-        id: setup-git-committer
-        uses: ./.github/actions/setup-git-committer
-        with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
-
-      - name: Fetch upstream
+      - name: Configure git
         run: |
-          git remote add upstream "$UPSTREAM_REPO" || true
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream "$UPSTREAM_REPO" || git remote set-url upstream "$UPSTREAM_REPO"
+          git fetch origin "$TARGET_BRANCH"
           git fetch upstream "$UPSTREAM_REF"
 
-      - name: Check upstream commit threshold
+      - name: Check upstream threshold
         id: threshold
         run: |
-          BEHIND=$(git rev-list --right-only --count "origin/$TARGET_BRANCH...upstream/$UPSTREAM_REF")
-          echo "behind_count=$BEHIND" >> "$GITHUB_OUTPUT"
+          behind_count="$(git rev-list --count "origin/${TARGET_BRANCH}..upstream/${UPSTREAM_REF}")"
 
-          if [ "$BEHIND" -lt "$MIN_COMMITS" ]; then
-            echo "should_sync=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping sync. Upstream is only $BEHIND commits ahead."
-          else
+          echo "behind_count=$behind_count" >> "$GITHUB_OUTPUT"
+          echo "minimum_commits=$MIN_COMMITS" >> "$GITHUB_OUTPUT"
+
+          if [ "$behind_count" -ge "$MIN_COMMITS" ]; then
             echo "should_sync=true" >> "$GITHUB_OUTPUT"
+            echo "Upstream is $behind_count commits ahead. Sync threshold met."
+          else
+            echo "should_sync=false" >> "$GITHUB_OUTPUT"
+            echo "Upstream is $behind_count commits ahead. Sync threshold not met."
           fi
 
-      - name: Create sync branch from dev
-        if: steps.threshold.outputs.should_sync == 'true'
-        run: git checkout -B "$SYNC_BRANCH"
+          {
+            echo "## Upstream Sync Threshold Check"
+            echo
+            echo "- Target branch: \`$TARGET_BRANCH\`"
+            echo "- Upstream ref: \`$UPSTREAM_REF\`"
+            echo "- Commits behind upstream: \`$behind_count\`"
+            echo "- Minimum threshold: \`$MIN_COMMITS\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Merge upstream into sync branch
+      - name: Stop when threshold is not met
+        if: steps.threshold.outputs.should_sync != 'true'
+        run: |
+          echo "Skipping upstream sync because threshold was not met."
+
+      - name: Create sync branch
+        if: steps.threshold.outputs.should_sync == 'true'
+        run: |
+          git checkout -B "$SYNC_BRANCH" "origin/$TARGET_BRANCH"
+
+      - name: Merge upstream
         id: merge
         if: steps.threshold.outputs.should_sync == 'true'
         run: |
-          if git merge "upstream/$UPSTREAM_REF" --no-edit; then
+          set +e
+          git merge --no-ff --no-edit "upstream/${UPSTREAM_REF}"
+          merge_status=$?
+          set -e
+
+          if [ "$merge_status" -eq 0 ]; then
             echo "result=success" >> "$GITHUB_OUTPUT"
-            echo "conflicted_files=" >> "$GITHUB_OUTPUT"
-          else
-            echo "result=conflict" >> "$GITHUB_OUTPUT"
-            conflicted_files=$(git diff --name-only --diff-filter=U | paste -sd "," -)
-            echo "conflicted_files=$conflicted_files" >> "$GITHUB_OUTPUT"
-            echo "Conflicted files:"
-            git diff --name-only --diff-filter=U || true
+            echo "Upstream merge completed without conflicts."
+            exit 0
           fi
+
+          if git diff --name-only --diff-filter=U | grep -q .; then
+            conflicted_files="$(git diff --name-only --diff-filter=U || true)"
+
+            echo "result=conflict" >> "$GITHUB_OUTPUT"
+            {
+              echo "conflicted_files<<EOF"
+              echo "$conflicted_files"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+
+            echo "Merge conflicts detected:"
+            echo "$conflicted_files"
+            exit 0
+          fi
+
+          echo "result=failed" >> "$GITHUB_OUTPUT"
+          echo "Merge failed for a reason other than conflicts."
+          exit "$merge_status"
 
       - name: Attempt automated conflict resolution
         id: resolution
         if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict'
+        continue-on-error: true
         run: .github/scripts/resolve-conflicts.sh
+
+      - name: Publish conflict resolution summary
+        if: always() && steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict'
+        run: |
+          if [ -f /tmp/resolution-summary.md ]; then
+            cat /tmp/resolution-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No conflict resolution summary was generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload conflict resolution artifacts
+        if: always() && steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict'
+        uses: actions/upload-artifact@v4
+        with:
+          name: upstream-sync-conflict-resolution
+          path: |
+            /tmp/resolution-summary.md
+            .github/conflict-rules.conf
+            .github/conflict-escalations.log
+          if-no-files-found: ignore
+
+      - name: Fail if conflicts require manual review
+        if: always() && steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge != 'true'
+        run: |
+          echo "Automated conflict resolution escalated one or more files for manual review."
+          echo "Review the workflow summary and uploaded conflict resolution artifacts."
+          exit 1
 
       - name: Commit automated resolution
         if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge == 'true'
@@ -104,156 +165,73 @@ jobs:
             git commit -m "chore(sync): automated conflict resolution"
           fi
 
-      - name: Run typecheck after automated resolution
-        id: resolution_typecheck
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge == 'true'
-        continue-on-error: true
+      - name: Check sync changes
+        id: sync_changes
+        if: steps.threshold.outputs.should_sync == 'true' && (steps.merge.outputs.result == 'success' || steps.resolution.outputs.can_complete_merge == 'true')
+        run: |
+          if git diff --quiet "origin/${TARGET_BRANCH}..HEAD"; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No sync changes detected after merge."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Sync changes detected."
+          fi
+
+      - name: Setup Bun
+        if: steps.threshold.outputs.should_sync == 'true' && steps.sync_changes.outputs.has_changes == 'true'
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        if: steps.threshold.outputs.should_sync == 'true' && steps.sync_changes.outputs.has_changes == 'true'
+        run: bun install --frozen-lockfile
+
+      - name: Run typecheck after sync
+        if: steps.threshold.outputs.should_sync == 'true' && steps.sync_changes.outputs.has_changes == 'true'
         run: bun --cwd packages/opencode typecheck
-
-      - name: Run tests after automated resolution
-        id: resolution_tests
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge == 'true' && steps.resolution_typecheck.outcome == 'success'
-        continue-on-error: true
-        run: bun turbo test
-
-      - name: Push automated resolution branch
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge == 'true' && steps.resolution_typecheck.outcome == 'success' && steps.resolution_tests.outcome == 'success'
-        run: git push origin "$SYNC_BRANCH" --force-with-lease
-
-      - name: Count new commits
-        id: diff
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'success'
-        run: echo "count=$(git rev-list origin/$TARGET_BRANCH..HEAD --count)" >> "$GITHUB_OUTPUT"
-
-      - name: Run typecheck
-        id: typecheck
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'success' && steps.diff.outputs.count != '0'
-        run: bun --cwd packages/opencode typecheck
-
-      - name: Run tests
-        id: tests
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'success' && steps.diff.outputs.count != '0' && steps.typecheck.outcome == 'success'
-        run: bun turbo test
 
       - name: Push sync branch
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'success' && steps.diff.outputs.count != '0' && steps.typecheck.outcome == 'success' && steps.tests.outcome == 'success'
-        run: git push origin "$SYNC_BRANCH" --force-with-lease
+        if: steps.threshold.outputs.should_sync == 'true' && steps.sync_changes.outputs.has_changes == 'true'
+        run: |
+          git push --force-with-lease origin "$SYNC_BRANCH"
 
-      - name: Create or update PR
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'success' && steps.diff.outputs.count != '0' && steps.typecheck.outcome == 'success' && steps.tests.outcome == 'success'
+      - name: Create or update upstream sync PR
+        if: steps.threshold.outputs.should_sync == 'true' && steps.sync_changes.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          date=$(date +%Y-%m-%d)
-          body="Automated upstream sync from \`sst/opencode\` — $date.
+          existing_pr="$(gh pr list \
+            --head "$SYNC_BRANCH" \
+            --base "$TARGET_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number')"
 
-          Upstream commits detected: \`${{ steps.threshold.outputs.behind_count }}\`
+          pr_title="chore(sync): upstream sync after threshold met"
 
-          Validation (typecheck + tests) passed. Awaiting team review before merge into \`$TARGET_BRANCH\`."
+          pr_body="$(cat <<EOF
+          ## Upstream sync
 
-          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH" --json number --jq '.[0].number')
-          if [ -n "$existing" ]; then
-            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" --title "chore: upstream sync $date" --body "$body"
+          This PR was created by the threshold-based upstream sync workflow.
+
+          - Upstream ref: \`$UPSTREAM_REF\`
+          - Target branch: \`$TARGET_BRANCH\`
+          - Commits behind upstream: \`${{ steps.threshold.outputs.behind_count }}\`
+          - Minimum threshold: \`${{ steps.threshold.outputs.minimum_commits }}\`
+
+          The workflow attempted to merge upstream changes and ran validation after the sync branch was prepared.
+          EOF
+          )"
+
+          if [ -n "$existing_pr" ]; then
+            echo "Updating existing PR #$existing_pr"
+            gh pr edit "$existing_pr" \
+              --title "$pr_title" \
+              --body "$pr_body"
           else
-            gh pr create --repo "$GITHUB_REPOSITORY" --title "chore: upstream sync $date" --body "$body" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH"
+            echo "Creating new upstream sync PR"
+            gh pr create \
+              --base "$TARGET_BRANCH" \
+              --head "$SYNC_BRANCH" \
+              --title "$pr_title" \
+              --body "$pr_body"
           fi
-
-      - name: Create or update automated resolution PR
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge == 'true' && steps.resolution_typecheck.outcome == 'success' && steps.resolution_tests.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          date=$(date +%Y-%m-%d)
-          summary=$(cat /tmp/resolution-summary.md 2>/dev/null || echo "No automated resolution summary was generated.")
-          body="Automated upstream sync from \`sst/opencode\` — $date.
-
-          Upstream commits detected: \`${{ steps.threshold.outputs.behind_count }}\`
-
-          Merge conflicts were detected and the automated resolution pipeline resolved them successfully.
-
-          Validation (typecheck + tests) passed. Awaiting team review before merge into \`$TARGET_BRANCH\`.
-
-          $summary"
-
-          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH" --json number --jq '.[0].number')
-          if [ -n "$existing" ]; then
-            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" --title "chore: upstream sync automated resolution $date" --body "$body"
-          else
-            gh pr create --repo "$GITHUB_REPOSITORY" --title "chore: upstream sync automated resolution $date" --body "$body" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH"
-          fi
-
-      - name: Create sync branch from upstream for conflict review
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && (steps.resolution.outputs.can_complete_merge != 'true' || steps.resolution_typecheck.outcome == 'failure' || steps.resolution_tests.outcome == 'failure')
-        run: |
-          git merge --abort || true
-          git checkout -B "$SYNC_BRANCH" "upstream/$UPSTREAM_REF"
-          git rm -rf .github/workflows/
-          git checkout "origin/$TARGET_BRANCH" -- .github/workflows/
-          git commit -m "chore: restore fork workflow files for sync PR"
-          git push origin "$SYNC_BRANCH" --force-with-lease
-
-      - name: Create or update conflict review PR
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && (steps.resolution.outputs.can_complete_merge != 'true' || steps.resolution_typecheck.outcome == 'failure' || steps.resolution_tests.outcome == 'failure')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          date=$(date +%Y-%m-%d)
-          summary=$(cat /tmp/resolution-summary.md 2>/dev/null || echo "No automated resolution summary was generated.")
-          body="Automated upstream sync from \`sst/opencode\` hit merge conflicts on $date.
-
-          Upstream commits detected: \`${{ steps.threshold.outputs.behind_count }}\`
-
-          The automated resolution pipeline attempted to resolve the conflicts but could not safely complete the sync.
-
-          Conflicted files:
-          \`${{ steps.merge.outputs.conflicted_files }}\`
-
-          $summary"
-
-          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH" --json number --jq '.[0].number')
-          if [ -n "$existing" ]; then
-            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" --title "chore: upstream sync conflict review $date" --body "$body"
-          else
-            gh pr create --repo "$GITHUB_REPOSITORY" --draft --title "chore: upstream sync conflict review $date" --body "$body" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH"
-          fi
-
-      - name: Open issue on merge conflict
-        if: always() && steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && (steps.resolution.outputs.can_complete_merge != 'true' || steps.resolution_typecheck.outcome == 'failure' || steps.resolution_tests.outcome == 'failure')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          date=$(date +%Y-%m-%d)
-          summary=$(cat /tmp/resolution-summary.md 2>/dev/null || echo "No automated resolution summary was generated.")
-          gh issue create \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "Upstream sync conflict — $date" \
-            --body "The upstream sync from \`sst/opencode\` detected merge conflicts on $date.
-
-          Upstream commits detected: \`${{ steps.threshold.outputs.behind_count }}\`
-
-          Conflicted files:
-          \`${{ steps.merge.outputs.conflicted_files }}\`
-
-          Automated resolution was attempted but the workflow fell back to human review.
-
-          $summary" \
-            --label bug
-
-      - name: Fail on unresolved merge conflict
-        if: always() && steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && (steps.resolution.outputs.can_complete_merge != 'true' || steps.resolution_typecheck.outcome == 'failure' || steps.resolution_tests.outcome == 'failure')
-        run: exit 1
-
-      - name: Open issue on validation failure
-        if: always() && steps.threshold.outputs.should_sync == 'true' && (steps.typecheck.outcome == 'failure' || steps.tests.outcome == 'failure')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh issue create \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "Upstream sync validation failed — $(date +%Y-%m-%d)" \
-            --body "The upstream sync from \`sst/opencode\` merged successfully on $(date +%Y-%m-%d) but failed validation (typecheck or tests).
-
-          Upstream commits detected: \`${{ steps.threshold.outputs.behind_count }}\`
-
-          The sync branch \`$SYNC_BRANCH\` has not been pushed because validation failed. Manual review is required before merging into \`$TARGET_BRANCH\`." \
-            --label bug

--- a/.github/workflows/upstream-sync-threshold.yml
+++ b/.github/workflows/upstream-sync-threshold.yml
@@ -13,7 +13,7 @@ on:
       min_commits:
         description: "Minimum upstream commits required before running sync"
         required: false
-        default: "10"
+        default: "75"
         type: string
 
 concurrency:
@@ -34,7 +34,7 @@ jobs:
       UPSTREAM_REPO: https://github.com/sst/opencode.git
       UPSTREAM_REF: ${{ inputs.upstream_ref || 'dev' }}
       TARGET_BRANCH: dev
-      MIN_COMMITS: ${{ inputs.min_commits || '10' }}
+      MIN_COMMITS: ${{ inputs.min_commits || '75' }}
     steps:
       - name: Checkout dev
         uses: actions/checkout@v4
@@ -88,26 +88,42 @@ jobs:
             echo "conflicted_files=$conflicted_files" >> "$GITHUB_OUTPUT"
             echo "Conflicted files:"
             git diff --name-only --diff-filter=U || true
-            git merge --abort
           fi
+
+      - name: Attempt automated conflict resolution
+        id: resolution
+        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict'
+        run: .github/scripts/resolve-conflicts.sh
+
+      - name: Commit automated resolution
+        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge == 'true'
+        run: |
+          if git diff --cached --quiet; then
+            echo "No staged automated conflict resolutions to commit."
+          else
+            git commit -m "chore(sync): automated conflict resolution"
+          fi
+
+      - name: Run typecheck after automated resolution
+        id: resolution_typecheck
+        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge == 'true'
+        continue-on-error: true
+        run: bun --cwd packages/opencode typecheck
+
+      - name: Run tests after automated resolution
+        id: resolution_tests
+        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge == 'true' && steps.resolution_typecheck.outcome == 'success'
+        continue-on-error: true
+        run: bun turbo test
+
+      - name: Push automated resolution branch
+        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge == 'true' && steps.resolution_typecheck.outcome == 'success' && steps.resolution_tests.outcome == 'success'
+        run: git push origin "$SYNC_BRANCH" --force-with-lease
 
       - name: Count new commits
         id: diff
         if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'success'
         run: echo "count=$(git rev-list origin/$TARGET_BRANCH..HEAD --count)" >> "$GITHUB_OUTPUT"
-
-      - name: Push sync branch
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'success' && steps.diff.outputs.count != '0'
-        run: git push origin "$SYNC_BRANCH" --force-with-lease
-
-      - name: Create sync branch from upstream (for conflict PR)
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict'
-        run: |
-          git checkout -B "$SYNC_BRANCH" "upstream/$UPSTREAM_REF"
-          git rm -rf .github/workflows/
-          git checkout "origin/$TARGET_BRANCH" -- .github/workflows/
-          git commit -m "chore: restore fork workflow files for sync PR"
-          git push origin "$SYNC_BRANCH" --force-with-lease
 
       - name: Run typecheck
         id: typecheck
@@ -118,6 +134,10 @@ jobs:
         id: tests
         if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'success' && steps.diff.outputs.count != '0' && steps.typecheck.outcome == 'success'
         run: bun turbo test
+
+      - name: Push sync branch
+        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'success' && steps.diff.outputs.count != '0' && steps.typecheck.outcome == 'success' && steps.tests.outcome == 'success'
+        run: git push origin "$SYNC_BRANCH" --force-with-lease
 
       - name: Create or update PR
         if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'success' && steps.diff.outputs.count != '0' && steps.typecheck.outcome == 'success' && steps.tests.outcome == 'success'
@@ -133,74 +153,94 @@ jobs:
 
           existing=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH" --json number --jq '.[0].number')
           if [ -n "$existing" ]; then
-            gh pr edit "$existing" \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "chore: upstream sync $date" \
-              --body "$body"
-            echo "Updated existing PR #$existing"
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" --title "chore: upstream sync $date" --body "$body"
           else
-            gh pr create \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "chore: upstream sync $date" \
-              --body "$body" \
-              --head "$SYNC_BRANCH" \
-              --base "$TARGET_BRANCH"
+            gh pr create --repo "$GITHUB_REPOSITORY" --title "chore: upstream sync $date" --body "$body" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH"
           fi
 
-      - name: Create or update conflict review PR
-        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict'
+      - name: Create or update automated resolution PR
+        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && steps.resolution.outputs.can_complete_merge == 'true' && steps.resolution_typecheck.outcome == 'success' && steps.resolution_tests.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           date=$(date +%Y-%m-%d)
+          summary=$(cat /tmp/resolution-summary.md 2>/dev/null || echo "No automated resolution summary was generated.")
+          body="Automated upstream sync from \`sst/opencode\` — $date.
+
+          Upstream commits detected: \`${{ steps.threshold.outputs.behind_count }}\`
+
+          Merge conflicts were detected and the automated resolution pipeline resolved them successfully.
+
+          Validation (typecheck + tests) passed. Awaiting team review before merge into \`$TARGET_BRANCH\`.
+
+          $summary"
+
+          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" --title "chore: upstream sync automated resolution $date" --body "$body"
+          else
+            gh pr create --repo "$GITHUB_REPOSITORY" --title "chore: upstream sync automated resolution $date" --body "$body" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH"
+          fi
+
+      - name: Create sync branch from upstream for conflict review
+        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && (steps.resolution.outputs.can_complete_merge != 'true' || steps.resolution_typecheck.outcome == 'failure' || steps.resolution_tests.outcome == 'failure')
+        run: |
+          git merge --abort || true
+          git checkout -B "$SYNC_BRANCH" "upstream/$UPSTREAM_REF"
+          git rm -rf .github/workflows/
+          git checkout "origin/$TARGET_BRANCH" -- .github/workflows/
+          git commit -m "chore: restore fork workflow files for sync PR"
+          git push origin "$SYNC_BRANCH" --force-with-lease
+
+      - name: Create or update conflict review PR
+        if: steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && (steps.resolution.outputs.can_complete_merge != 'true' || steps.resolution_typecheck.outcome == 'failure' || steps.resolution_tests.outcome == 'failure')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          date=$(date +%Y-%m-%d)
+          summary=$(cat /tmp/resolution-summary.md 2>/dev/null || echo "No automated resolution summary was generated.")
           body="Automated upstream sync from \`sst/opencode\` hit merge conflicts on $date.
 
           Upstream commits detected: \`${{ steps.threshold.outputs.behind_count }}\`
 
-          This PR contains upstream's latest code. Use the Resolve conflicts button to pick and choose changes visually.
+          The automated resolution pipeline attempted to resolve the conflicts but could not safely complete the sync.
 
           Conflicted files:
-          \`${{ steps.merge.outputs.conflicted_files }}\`"
+          \`${{ steps.merge.outputs.conflicted_files }}\`
+
+          $summary"
 
           existing=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH" --json number --jq '.[0].number')
           if [ -n "$existing" ]; then
-            gh pr edit "$existing" \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "chore: upstream sync conflict review $date" \
-              --body "$body"
-            echo "Updated existing conflict review PR #$existing"
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" --title "chore: upstream sync conflict review $date" --body "$body"
           else
-            gh pr create \
-              --repo "$GITHUB_REPOSITORY" \
-              --draft \
-              --title "chore: upstream sync conflict review $date" \
-              --body "$body" \
-              --head "$SYNC_BRANCH" \
-              --base "$TARGET_BRANCH"
+            gh pr create --repo "$GITHUB_REPOSITORY" --draft --title "chore: upstream sync conflict review $date" --body "$body" --head "$SYNC_BRANCH" --base "$TARGET_BRANCH"
           fi
 
       - name: Open issue on merge conflict
-        if: always() && steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict'
+        if: always() && steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && (steps.resolution.outputs.can_complete_merge != 'true' || steps.resolution_typecheck.outcome == 'failure' || steps.resolution_tests.outcome == 'failure')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          date=$(date +%Y-%m-%d)
+          summary=$(cat /tmp/resolution-summary.md 2>/dev/null || echo "No automated resolution summary was generated.")
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \
-            --title "Upstream sync conflict — $(date +%Y-%m-%d)" \
-            --body "The upstream sync from \`sst/opencode\` detected merge conflicts on $(date +%Y-%m-%d).
+            --title "Upstream sync conflict — $date" \
+            --body "The upstream sync from \`sst/opencode\` detected merge conflicts on $date.
 
           Upstream commits detected: \`${{ steps.threshold.outputs.behind_count }}\`
 
           Conflicted files:
           \`${{ steps.merge.outputs.conflicted_files }}\`
 
-          A draft PR was also opened/updated for review using the \`$SYNC_BRANCH\` branch.
+          Automated resolution was attempted but the workflow fell back to human review.
 
-          Manual intervention is required to sync the latest upstream changes into \`$TARGET_BRANCH\`. Please resolve conflicts and merge manually." \
+          $summary" \
             --label bug
 
-      - name: Fail on merge conflict
-        if: always() && steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict'
+      - name: Fail on unresolved merge conflict
+        if: always() && steps.threshold.outputs.should_sync == 'true' && steps.merge.outputs.result == 'conflict' && (steps.resolution.outputs.can_complete_merge != 'true' || steps.resolution_typecheck.outcome == 'failure' || steps.resolution_tests.outcome == 'failure')
         run: exit 1
 
       - name: Open issue on validation failure
@@ -215,5 +255,5 @@ jobs:
 
           Upstream commits detected: \`${{ steps.threshold.outputs.behind_count }}\`
 
-          The sync branch \`$SYNC_BRANCH\` has been pushed. Manual review is required before merging into \`$TARGET_BRANCH\`." \
+          The sync branch \`$SYNC_BRANCH\` has not been pushed because validation failed. Manual review is required before merging into \`$TARGET_BRANCH\`." \
             --label bug


### PR DESCRIPTION
### Issue for this PR

Closes #267

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Refactor / code improvement
* [ ] Documentation

### What does this PR do?

This PR adds an automated conflict resolution step to the threshold-based upstream sync workflow.

Before this change, when the upstream sync hit merge conflicts, the workflow immediately aborted the merge. That made sense for the first version of the threshold workflow, but it did not give us a chance to handle simple or predictable conflicts automatically.

This update keeps the merge state available when conflicts are detected, then runs `.github/scripts/resolve-conflicts.sh` to inspect the conflicted files and attempt automated resolution. If the script can resolve the conflicts, it stages the resolved files, allows the workflow to commit the automated resolution, and then runs typecheck validation afterward. If conflicts still need manual review, the workflow reports them instead of silently continuing.

I also updated the default sync threshold from 10 commits to 75 commits so the workflow only creates sync work when the fork is meaningfully behind upstream.

### How did you verify your code works?

* Ran `bash -n .github/scripts/resolve-conflicts.sh` to verify the script syntax
* Ran `git diff --check` to check for whitespace issues
* Ran `git diff --cached --check` before committing
* Reviewed the staged diff for both `.github/scripts/resolve-conflicts.sh` and `.github/workflows/upstream-sync-threshold.yml`
* Confirmed only the intended workflow and script files were included in the commit

### Screenshots / recordings

N/A — this is a workflow/script change.

### Checklist

* [x] I have tested my changes locally
* [x] I have not included unrelated changes in this PR

*If you do not follow this template your PR will be automatically rejected.*
